### PR TITLE
fix(docs): formatting in Edge AI Architecture section

### DIFF
--- a/Module01/01.EdgeAIFundamentals.md
+++ b/Module01/01.EdgeAIFundamentals.md
@@ -63,7 +63,7 @@ The key conceptual pillars of Edge AI include:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                         TRADITIONAL AI ARCHITECTURE                  │
+│                         TRADITIONAL AI ARCHITECTURE                 │
 └─────────────────────────────────────────────────────────────────────┘
                                   │
 ┌──────────────┐   Data Transfer  ┌───────────────┐   API Response   ┌───────────┐
@@ -75,15 +75,15 @@ The key conceptual pillars of Edge AI include:
                                   Privacy Concerns
                                
 ┌─────────────────────────────────────────────────────────────────────┐
-│                            EDGE AI ARCHITECTURE                      │
+│                            EDGE AI ARCHITECTURE                     │
 └─────────────────────────────────────────────────────────────────────┘
                                   │
-┌──────────────────────────────────────────────────┐   Direct Response   ┌───────────┐
-│              Edge Devices with Embedded AI        │───────────────────>│ End Users │
-│  ┌─────────┐  ┌──────────────┐  ┌──────────────┐ │                    └───────────┘
-│  │ Sensors │─>│ SLM Inference │─>│ Local Action │ │
-│  └─────────┘  └──────────────┘  └──────────────┘ │
-└──────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────┐   Direct Response  ┌───────────┐
+│              Edge Devices with Embedded AI         │───────────────────>│ End Users │
+│  ┌─────────┐  ┌───────────────┐  ┌──────────────┐  │                    └───────────┘
+│  │ Sensors │─>│ SLM Inference │─>│ Local Action │  │
+│  └─────────┘  └───────────────┘  └──────────────┘  │
+└────────────────────────────────────────────────────┘
      Data         Low Latency       Immediate
    Collection     Processing        Response
                   No Data Transfer


### PR DESCRIPTION
Plaintext diagrams are hard to maintain and some of the edges of the diagram had lost their alignment.  This corrects the alignment.