### PR TITLE
Fix API signature mismatch in session06_models_router.ipynb

### DIFF
--- a/Workshop/notebooks/session06_models_router.ipynb
+++ b/Workshop/notebooks/session06_models_router.ipynb
@@ -437,7 +437,7 @@
     "                continue\n",
     "                \n",
     "            try:\n",
-    "                manager, client, model_id = get_client(model, None)\n",
+    "                manager, client, model_id = get_client(model)\n",
     "                response = client.chat.completions.create(\n",
     "                    model=model_id,\n",
     "                    messages=[{\"role\": \"user\", \"content\": \"test\"}],\n",


### PR DESCRIPTION
Problem:
- Line 68 incorrectly called get_client(model, None) in Step 3: Automatic Model Loading
- The get_client() function signature is: get_client(alias: str, endpoint: Optional[str] = None)
- Passing None as a positional argument caused "get_client() takes 1 positional argument but 2 were given" error
- This caused the model verification step to fail 30 times with 0/3 models ready

Solution:
- Changed get_client(model, None) to get_client(model)
- This uses the default value for the endpoint parameter



